### PR TITLE
Support OpenShift; add health/readiness checks; miscellaneous fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8 as builder
+FROM golang:1.11 as builder
 
 ADD . /go/src/github.com/fntlnz/caturday
 
@@ -10,5 +10,6 @@ FROM scratch
 
 COPY --from=builder /go/src/github.com/fntlnz/caturday/caturday /caturday
 
+USER 10000
 EXPOSE 8080
 ENTRYPOINT ["/caturday"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ or if your ingress is not `nginx` or you don'w want to automatically get certifi
 kubectl apply -f https://raw.githubusercontent.com/fntlnz/caturday/master/caturday.yml
 ```
 
+## Usage with Red Hat OpenShift
+
+First, create a new OpenShift project:
+
+```
+oc new-project caturday
+```
+
+I provide an [example set of OpenShift definitions](caturday-openshift) that
+uses [`openshift-acme`](https://github.com/tnozicka/openshift-acme) to
+automatically secure the route for the application. Edit it as needed, then
+run:
+
+```
+oc create -f caturday-openshift.yml
+```
+
 ## Usage with Docker
 
 ```

--- a/caturday-openshift.yml
+++ b/caturday-openshift.yml
@@ -1,0 +1,89 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    app: caturday
+  name: caturday
+spec:
+  dockerImageRepository: docker.io/fntlnz/caturday
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: docker.io/fntlnz/caturday
+    referencePolicy:
+      type: Local
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  labels:
+    app: caturday
+  name: caturday
+spec:
+  replicas: 1
+  selector:
+    app: caturday
+    deploymentconfig: caturday
+  strategy:
+    type: Rolling
+  template:
+    metadata:
+      labels:
+        app: caturday
+        deploymentconfig: caturday
+    spec:
+      containers:
+        - image: caturday
+          imagePullPolicy: Always
+          name: caturday
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+  triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - caturday
+        from:
+          kind: ImageStreamTag
+          name: 'caturday:latest'
+      type: ImageChange
+    - type: ConfigChange
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: caturday
+spec:
+  selector:
+    app: caturday
+  ports:
+  - name: 80-tcp
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    kubernetes.io/tls-acme: 'true'
+  labels:
+    app: caturday
+  name: caturday
+spec:
+  port:
+    targetPort: 80-tcp
+  to:
+    kind: Service
+    name: caturday
+  wildcardPolicy: None
+  tls:
+    termination: edge


### PR DESCRIPTION
* Add a caturday-openshift.yml template to use Caturday on OpenShift.
* Update the Golang builder to v1.11.
* Run Caturday as a non-privileged user.
* Add health and readiness checks.
* Fix a small typo in the image URL encoding.