### PR TITLE
README.md: typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ First, create a new OpenShift project:
 oc new-project caturday
 ```
 
-I provide an [example set of OpenShift definitions](caturday-openshift) that
+I provide an [example set of OpenShift definitions](caturday-openshift.yml) that
 uses [`openshift-acme`](https://github.com/tnozicka/openshift-acme) to
 automatically secure the route for the application. Edit it as needed, then
 run:


### PR DESCRIPTION
Fix a typo in the README file (the `.yml` extension in the link to the OpenShift definitions was missing).